### PR TITLE
Update pyproject.toml to be compatible with LangGraph Platform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "langgraph>=0.2.34,<0.3.0",
+    "langgraph>=0.5.2",
     # Optional (for selecting different models)
-    "langchain-openai>=0.2.1",
-    "langchain-anthropic>=0.2.1",
-    "langchain>=0.3.8",
-    "langchain-core>=0.3.8",
-    "python-dotenv>=1.0.1",
-    "langgraph-sdk>=0.1.32",
+    "langchain-openai>=0.3.27",
+    "langchain-anthropic>=0.3.17",
+    "langchain>=0.3.26",
+    "langchain-core>=0.3.68",
+    "python-dotenv>=1.1.1",
+    "langgraph-sdk>=0.1.72",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The current version of pyproject.toml throws dependency error when deployed on the current version of LangGraph Platform (Cloud SaaS). The dependencies are updated to functional versions.