### PR TITLE
Add permissions block to CI workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,6 +7,9 @@ on:
     - cron: "37 14 * * *" # Run at 7:37 AM Pacific Time (14:37 UTC) every day
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another scheduled run starts while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch: # Allows triggering the workflow manually in GitHub UI
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 concurrency:


### PR DESCRIPTION
## Summary
- Adds `permissions: contents: read` to both `unit-tests.yml` and `integration-tests.yml` workflows
- Resolves code scanning alerts [#1](https://github.com/langchain-ai/memory-agent/security/code-scanning/1) and [#2](https://github.com/langchain-ai/memory-agent/security/code-scanning/2) (`actions/missing-workflow-permissions`)
- Neither workflow requires write access — they only check out code and run tests

## Test plan
- [x] Verify unit-tests workflow passes on this PR
- [x] Verify integration-tests workflow can be triggered manually and still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)